### PR TITLE
Tag OpenGL tests with `opengl: true`.

### DIFF
--- a/test/opengl/opengl_cpp_native_test.exs
+++ b/test/opengl/opengl_cpp_native_test.exs
@@ -7,6 +7,7 @@ defmodule VideoCompositor.OpenGL.Cpp.Native.Test do
 
   describe "OpenGL cpp native test on " do
     @describetag :tmp_dir
+    @describetag opengl: true
 
     test "compose doubled raw video frames on top of each other", %{tmp_dir: tmp_dir} do
       {in_path, out_path, ref_path} = Utility.prepare_paths("1frame.yuv", tmp_dir, "native")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,6 @@
 excluded = [
-  long: true
+  long: true,
+  opengl: true
 ]
 
 ExUnit.start(capture_log: true, exclude: excluded)


### PR DESCRIPTION
This makes OpenGL-based tests ignored in the CI. This is a temporary solution.
Hopefully soon we'll either have a CI machine able to run OpenGL correctly or at least be able to detect whether we're running in the CI environment to exclude these tests only in there.