### PR TITLE
Fix the C++ OpenGL compositor on Linux

### DIFF
--- a/c_src/opengl_video_compositor/RectVAO.cpp
+++ b/c_src/opengl_video_compositor/RectVAO.cpp
@@ -25,7 +25,7 @@ RectVAO::RectVAO(const std::vector<float> &vertices,
   glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void *)0);
   glEnableVertexAttribArray(0);
 
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float),
+  glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float),
                         (void *)(3 * sizeof(float)));
   glEnableVertexAttribArray(1);
 


### PR DESCRIPTION
We used to tell OpenGL that the length of our texture coordinates vector is 3.
This is obviously wrong, since texture coordinates are 2-dimensional.
Native macOS OpenGL driver and Google ANGLE were both able to figure out from
the shader code that this is the case and correct it (that's what I
think at least), however Linux drivers weren't. Now the code is correct
and works!