### PR TITLE
Improve our OpenGL error-handling infrastructure.

### DIFF
--- a/native/membrane_videocompositor_opengl_rust/Cargo.lock
+++ b/native/membrane_videocompositor_opengl_rust/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "glad-gles2",
  "khronos-egl",
  "rustler",
+ "thiserror",
 ]
 
 [[package]]
@@ -141,6 +142,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/native/membrane_videocompositor_opengl_rust/Cargo.toml
+++ b/native/membrane_videocompositor_opengl_rust/Cargo.toml
@@ -13,3 +13,4 @@ crate-type = ["cdylib"]
 rustler = "0.25.0"
 khronos-egl = { version = "4.1.0", features = ["static", "no-pkg-config"] }
 glad-gles2 = { path = "glad-gles2" }
+thiserror = "1.0.32"

--- a/native/membrane_videocompositor_opengl_rust/src/errors.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/errors.rs
@@ -13,8 +13,7 @@ pub fn result_or_gl_error<T>(
     res: T,
     file: &str,
     line: u32,
-    function: &str,
-    args: &str,
+    call: &str,
 ) -> Result<T, CompositorError> {
     use glad_gles2::gl;
 
@@ -27,7 +26,7 @@ pub fn result_or_gl_error<T>(
     let location = ErrorLocation {
         file: file.to_string(),
         line,
-        call: format!("gl{}({})", function, args),
+        call: call.to_string(),
     };
 
     match err {

--- a/native/membrane_videocompositor_opengl_rust/src/errors.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/errors.rs
@@ -1,4 +1,3 @@
-use crate::gl;
 use thiserror::Error;
 
 #[derive(Debug, rustler::NifStruct)]
@@ -10,21 +9,19 @@ pub struct ErrorLocation {
     pub call: String,
 }
 
-pub fn result_or_gl_error<T>(
-    res: T,
-    err: u32,
-    location: ErrorLocation,
-) -> Result<T, CompositorError> {
+pub fn result_or_gl_error<T>(res: T, location: ErrorLocation) -> Result<T, CompositorError> {
+    use glad_gles2::gl;
+    let err = unsafe { gl::GetError() };
     match err {
-        gl!(NO_ERROR) => Ok(res),
-        gl!(INVALID_ENUM) => Err(CompositorError::GLError("gl_invalid_enum", location)),
-        gl!(INVALID_VALUE) => Err(CompositorError::GLError("gl_invalid_value", location)),
-        gl!(INVALID_OPERATION) => Err(CompositorError::GLError("gl_invalid_opegation", location)),
-        gl!(INVALID_FRAMEBUFFER_OPERATION) => Err(CompositorError::GLError(
+        gl::NO_ERROR => Ok(res),
+        gl::INVALID_ENUM => Err(CompositorError::GLError("gl_invalid_enum", location)),
+        gl::INVALID_VALUE => Err(CompositorError::GLError("gl_invalid_value", location)),
+        gl::INVALID_OPERATION => Err(CompositorError::GLError("gl_invalid_operation", location)),
+        gl::INVALID_FRAMEBUFFER_OPERATION => Err(CompositorError::GLError(
             "gl_invalid_framebuffer_operations",
             location,
         )),
-        gl!(OUT_OF_MEMORY) => Err(CompositorError::GLError("gl_out_of_memory", location)),
+        gl::OUT_OF_MEMORY => Err(CompositorError::GLError("gl_out_of_memory", location)),
         _ => panic!("Error passed to result_or_gl_error is not an OpenGL error"),
     }
 }

--- a/native/membrane_videocompositor_opengl_rust/src/errors.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/errors.rs
@@ -1,0 +1,89 @@
+use crate::{gl, shaders::ShaderError};
+
+#[derive(Debug, rustler::NifStruct)]
+#[module = "Membrane.VideoCompositor.OpenGL.Rust.ErrorLocation"]
+pub struct ErrorLocation {
+    pub file: String,
+    pub line: u32,
+    pub call: String,
+}
+
+#[derive(Debug)]
+pub enum GLError {
+    InvalidEnum(ErrorLocation),
+    InvalidValue(ErrorLocation),
+    InvalidOperation(ErrorLocation),
+    InvalidFramebufferOperation(ErrorLocation),
+    OutOfMemory(ErrorLocation),
+}
+
+pub fn result_or_gl_error<T>(res: T, err: u32, location: ErrorLocation) -> Result<T, GLError> {
+    match err {
+        gl!(NO_ERROR) => Ok(res),
+        gl!(INVALID_ENUM) => Err(GLError::InvalidEnum(location)),
+        gl!(INVALID_VALUE) => Err(GLError::InvalidValue(location)),
+        gl!(INVALID_OPERATION) => Err(GLError::InvalidOperation(location)),
+        gl!(INVALID_FRAMEBUFFER_OPERATION) => Err(GLError::InvalidFramebufferOperation(location)),
+        gl!(OUT_OF_MEMORY) => Err(GLError::OutOfMemory(location)),
+        _ => panic!("Error passed to result_or_gl_error is not an OpenGL error"),
+    }
+}
+
+mod atoms {
+    rustler::atoms! {
+        invalid_enum,
+        invalid_value,
+        invalid_operation,
+        invalid_framebuffer_operation,
+        out_of_memory
+    }
+}
+
+impl From<GLError> for rustler::Error {
+    fn from(error: GLError) -> Self {
+        use rustler::Error;
+        match error {
+            GLError::InvalidEnum(location) => {
+                Error::Term(Box::new((atoms::invalid_enum(), location)))
+            }
+            GLError::InvalidValue(location) => {
+                Error::Term(Box::new((atoms::invalid_value(), location)))
+            }
+            GLError::InvalidOperation(location) => {
+                Error::Term(Box::new((atoms::invalid_operation(), location)))
+            }
+            GLError::InvalidFramebufferOperation(location) => {
+                Error::Term(Box::new((atoms::invalid_framebuffer_operation(), location)))
+            }
+            GLError::OutOfMemory(location) => {
+                Error::Term(Box::new((atoms::out_of_memory(), location)))
+            }
+        }
+    }
+}
+
+pub enum CompositorError {
+    ShaderError(ShaderError),
+    GLError(GLError),
+}
+
+impl From<ShaderError> for CompositorError {
+    fn from(error: ShaderError) -> Self {
+        Self::ShaderError(error)
+    }
+}
+
+impl From<GLError> for CompositorError {
+    fn from(error: GLError) -> Self {
+        Self::GLError(error)
+    }
+}
+
+impl From<CompositorError> for rustler::Error {
+    fn from(error: CompositorError) -> Self {
+        match error {
+            CompositorError::ShaderError(error) => error.into(),
+            CompositorError::GLError(error) => error.into(),
+        }
+    }
+}

--- a/native/membrane_videocompositor_opengl_rust/src/errors.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/errors.rs
@@ -1,89 +1,64 @@
-use crate::{gl, shaders::ShaderError};
+use crate::gl;
+use thiserror::Error;
 
 #[derive(Debug, rustler::NifStruct)]
 #[module = "Membrane.VideoCompositor.OpenGL.Rust.ErrorLocation"]
+/// Carries information about a location where an error happened
 pub struct ErrorLocation {
     pub file: String,
     pub line: u32,
     pub call: String,
 }
 
-#[derive(Debug)]
-pub enum GLError {
-    InvalidEnum(ErrorLocation),
-    InvalidValue(ErrorLocation),
-    InvalidOperation(ErrorLocation),
-    InvalidFramebufferOperation(ErrorLocation),
-    OutOfMemory(ErrorLocation),
-}
-
-pub fn result_or_gl_error<T>(res: T, err: u32, location: ErrorLocation) -> Result<T, GLError> {
+pub fn result_or_gl_error<T>(
+    res: T,
+    err: u32,
+    location: ErrorLocation,
+) -> Result<T, CompositorError> {
     match err {
         gl!(NO_ERROR) => Ok(res),
-        gl!(INVALID_ENUM) => Err(GLError::InvalidEnum(location)),
-        gl!(INVALID_VALUE) => Err(GLError::InvalidValue(location)),
-        gl!(INVALID_OPERATION) => Err(GLError::InvalidOperation(location)),
-        gl!(INVALID_FRAMEBUFFER_OPERATION) => Err(GLError::InvalidFramebufferOperation(location)),
-        gl!(OUT_OF_MEMORY) => Err(GLError::OutOfMemory(location)),
+        gl!(INVALID_ENUM) => Err(CompositorError::GLError("gl_invalid_enum", location)),
+        gl!(INVALID_VALUE) => Err(CompositorError::GLError("gl_invalid_value", location)),
+        gl!(INVALID_OPERATION) => Err(CompositorError::GLError("gl_invalid_opegation", location)),
+        gl!(INVALID_FRAMEBUFFER_OPERATION) => Err(CompositorError::GLError(
+            "gl_invalid_framebuffer_operations",
+            location,
+        )),
+        gl!(OUT_OF_MEMORY) => Err(CompositorError::GLError("gl_out_of_memory", location)),
         _ => panic!("Error passed to result_or_gl_error is not an OpenGL error"),
     }
 }
 
 mod atoms {
     rustler::atoms! {
-        invalid_enum,
-        invalid_value,
-        invalid_operation,
-        invalid_framebuffer_operation,
-        out_of_memory
+        error,
     }
 }
 
-impl From<GLError> for rustler::Error {
-    fn from(error: GLError) -> Self {
-        use rustler::Error;
-        match error {
-            GLError::InvalidEnum(location) => {
-                Error::Term(Box::new((atoms::invalid_enum(), location)))
+#[derive(Debug, Error)]
+/// An enum representing various errors that can happen during composition
+pub enum CompositorError {
+    #[error("shader compilation or linking error")]
+    ShaderError(&'static str),
+    #[error("error while calling OpenGL")]
+    GLError(&'static str, ErrorLocation),
+}
+
+impl rustler::Encoder for CompositorError {
+    fn encode<'a>(&self, env: rustler::Env<'a>) -> rustler::Term<'a> {
+        match self {
+            CompositorError::ShaderError(atom) => {
+                rustler::Atom::from_str(env, atom).unwrap().encode(env)
             }
-            GLError::InvalidValue(location) => {
-                Error::Term(Box::new((atoms::invalid_value(), location)))
-            }
-            GLError::InvalidOperation(location) => {
-                Error::Term(Box::new((atoms::invalid_operation(), location)))
-            }
-            GLError::InvalidFramebufferOperation(location) => {
-                Error::Term(Box::new((atoms::invalid_framebuffer_operation(), location)))
-            }
-            GLError::OutOfMemory(location) => {
-                Error::Term(Box::new((atoms::out_of_memory(), location)))
+            CompositorError::GLError(atom, location) => {
+                (rustler::Atom::from_str(env, atom).unwrap(), location).encode(env)
             }
         }
-    }
-}
-
-pub enum CompositorError {
-    ShaderError(ShaderError),
-    GLError(GLError),
-}
-
-impl From<ShaderError> for CompositorError {
-    fn from(error: ShaderError) -> Self {
-        Self::ShaderError(error)
-    }
-}
-
-impl From<GLError> for CompositorError {
-    fn from(error: GLError) -> Self {
-        Self::GLError(error)
     }
 }
 
 impl From<CompositorError> for rustler::Error {
     fn from(error: CompositorError) -> Self {
-        match error {
-            CompositorError::ShaderError(error) => error.into(),
-            CompositorError::GLError(error) => error.into(),
-        }
+        rustler::Error::Term(Box::new(error))
     }
 }

--- a/native/membrane_videocompositor_opengl_rust/src/lib.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/lib.rs
@@ -16,11 +16,7 @@ macro_rules! gl {
         {
             // FIXME: we should probably add something like `ensure_current_thread_holds_context` here
             let result = glad_gles2::gl::$call($($args),*);
-            crate::errors::result_or_gl_error(result, crate::errors::ErrorLocation {
-                file: file!().to_string(),
-                line: line!(),
-                call: format!("gl{}({})", stringify!($call), stringify!($($args),*))
-            })
+            crate::errors::result_or_gl_error(result, file!(), line!(), stringify!($call), stringify!($($args),*))
         }
     };
 }

--- a/native/membrane_videocompositor_opengl_rust/src/lib.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/lib.rs
@@ -16,19 +16,13 @@ macro_rules! gl {
         {
             // FIXME: we should probably add something like `ensure_current_thread_holds_context` here
             let result = glad_gles2::gl::$call($($args),*);
-            #[allow(unused_unsafe)] // we have this, because maybe there are some gl calls that are safe and in that case we need our own unsafe block here
-            let err = unsafe { glad_gles2::gl::GetError() };
-            crate::errors::result_or_gl_error(result, err, crate::errors::ErrorLocation {
+            crate::errors::result_or_gl_error(result, crate::errors::ErrorLocation {
                 file: file!().to_string(),
                 line: line!(),
                 call: format!("gl{}({})", stringify!($call), stringify!($($args),*))
             })
         }
     };
-
-    ($name:ident) => {
-        glad_gles2::gl::$name
-    }
 }
 
 pub(crate) use gl;

--- a/native/membrane_videocompositor_opengl_rust/src/lib.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/lib.rs
@@ -12,13 +12,11 @@ pub mod shaders;
 pub mod textures;
 
 macro_rules! gl {
-    ($call:ident($($args:expr),*)) => {
-        {
-            // FIXME: we should probably add something like `ensure_current_thread_holds_context` here
-            let result = glad_gles2::gl::$call($($args),*);
-            crate::errors::result_or_gl_error(result, file!(), line!(), stringify!($call), stringify!($($args),*))
-        }
-    };
+    ($call:expr) => {{
+        // FIXME: we should probably add something like `ensure_current_thread_holds_context` here
+        let result = $call;
+        crate::errors::result_or_gl_error(result, file!(), line!(), stringify!(call))
+    }};
 }
 
 pub(crate) use gl;
@@ -199,7 +197,7 @@ fn init(
             .expect("Can't find a GLES procedure") as *const std::ffi::c_void
     });
 
-    unsafe { gl!(ClearColor(0.0, 0.0, 0.0, 1.0))? }
+    unsafe { gl!(glad_gles2::gl::ClearColor(0.0, 0.0, 0.0, 1.0))? }
 
     let vertex_shader_code = include_str!("shaders/vertex.glsl");
     let fragment_shader_code = include_str!("shaders/fragment.glsl");

--- a/native/membrane_videocompositor_opengl_rust/src/lib.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/lib.rs
@@ -3,13 +3,35 @@
 
 extern crate khronos_egl as egl;
 
-use glad_gles2::gl;
 use rustler::ResourceArc;
 
+pub mod errors;
 pub mod framebuffers;
 pub mod scene;
 pub mod shaders;
 pub mod textures;
+
+macro_rules! gl {
+    ($call:ident($($args:expr),*)) => {
+        {
+            // FIXME: we should probably add something like `ensure_current_thread_holds_context` here
+            let result = glad_gles2::gl::$call($($args),*);
+            #[allow(unused_unsafe)] // we have this, because maybe there are some gl calls that are safe and in that case we need our own unsafe block here
+            let err = unsafe { glad_gles2::gl::GetError() };
+            crate::errors::result_or_gl_error(result, err, crate::errors::ErrorLocation {
+                file: file!().to_string(),
+                line: line!(),
+                call: format!("gl{}({})", stringify!($call), stringify!($($args),*))
+            })
+        }
+    };
+
+    ($name:ident) => {
+        glad_gles2::gl::$name
+    }
+}
+
+pub(crate) use gl;
 
 #[allow(non_snake_case)]
 mod atoms {
@@ -182,12 +204,12 @@ fn init(
     egl.make_current(display, None, None, Some(context))
         .nif_err()?;
 
-    gl::load(|name| {
+    glad_gles2::gl::load(|name| {
         egl.get_proc_address(name)
             .expect("Can't find a GLES procedure") as *const std::ffi::c_void
     });
 
-    unsafe { gl::ClearColor(0.0, 0.0, 0.0, 1.0) }
+    unsafe { gl!(ClearColor(0.0, 0.0, 0.0, 1.0))? }
 
     let vertex_shader_code = include_str!("shaders/vertex.glsl");
     let fragment_shader_code = include_str!("shaders/fragment.glsl");


### PR DESCRIPTION
This patch adds 2 things to the codebase:

 * a `gl` macro, which can be used when calling OpenGL functions. It
   calls an OpenGL function, does error-checking and returns an appropriate `Result` with a very nice (in my opinion) error.
   From now on, this macro should be the only way to call OpenGL.
 * some error-handling types: `GLError` for OpenGL errors and
   `CompositorError` for converting from various errors to the final
   `rustler::Error` in a convenient way.

Based on #12 