### PR TITLE
Rust lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,4 +12,10 @@ jobs:
           mix deps.get
           mix deps.compile --all
           mix format --check-formatted
+          for path in native/*
+          do
+            cargo fmt --manifest-path $path/Cargo.toml -- --check
+            cargo clippy --manifest-path $path/Cargo.toml -- -D warnings
+            cargo test --manifest-path $path/Cargo.toml
+          done
           mix test

--- a/native/membrane_videocompositor_opengl_rust/src/lib.rs
+++ b/native/membrane_videocompositor_opengl_rust/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(unsafe_op_in_unsafe_fn)]
+#![allow(clippy::extra_unused_lifetimes)] // we have to do this because of a bug in rustler.
 //! This crate is a video compositor implementation using OpenGL, intended for use with an Elixir package.
 
 extern crate khronos_egl as egl;


### PR DESCRIPTION
Enable rust lints and unit tests for all rust projects. Based on #20. Closes #19 