### PR TITLE
Fix frame composer internal state parameter order

### DIFF
--- a/lib/membrane/video_compositor.ex
+++ b/lib/membrane/video_compositor.ex
@@ -94,7 +94,7 @@ defmodule Membrane.VideoCompositor do
     id = Map.get(pads_to_ids, pad)
 
     position = Map.get(ids_to_tracks, id).position
-    {:ok, internal_state} = state.compositor_module.add_video(id, caps, position, internal_state)
+    {:ok, internal_state} = state.compositor_module.add_video(internal_state, id, caps, position)
 
     state = %{state | internal_state: internal_state}
     {:ok, state}
@@ -134,7 +134,7 @@ defmodule Membrane.VideoCompositor do
       ids_to_frames = get_ids_to_frames(ids_to_tracks)
 
       {{:ok, merged_frame_binary}, internal_state} =
-        state.compositor_module.merge_frames(ids_to_frames, internal_state)
+        state.compositor_module.merge_frames(internal_state, ids_to_frames)
 
       ids_to_tracks = pop_frames(ids_to_tracks)
 
@@ -207,7 +207,7 @@ defmodule Membrane.VideoCompositor do
   defp remove_track(state, id) do
     %{ids_to_tracks: ids_to_tracks, internal_state: internal_state} = state
     ids_to_tracks = Map.delete(ids_to_tracks, id)
-    {:ok, internal_state} = state.compositor_module.remove_video(id, internal_state)
+    {:ok, internal_state} = state.compositor_module.remove_video(internal_state, id)
     %{state | ids_to_tracks: ids_to_tracks, internal_state: internal_state}
   end
 

--- a/lib/membrane/video_compositor/frame_compositor.ex
+++ b/lib/membrane/video_compositor/frame_compositor.ex
@@ -5,43 +5,45 @@ defmodule Membrane.VideoCompositor.FrameCompositor do
   alias Membrane.RawVideo
 
   @type id_t() :: non_neg_integer()
+  @type internal_state_t() :: any()
+  @type error_t() :: any()
 
-  @callback init(output_caps :: RawVideo.t()) :: {:ok, state :: any()}
+  @callback init(output_caps :: RawVideo.t()) :: {:ok, internal_state_t} | {:error, error_t()}
 
   @doc """
   Frames are provided as tuples `{id, frame}` and given in the proper order of rendering (typically in ascending order of ids).
   Providing frames with wrong ids may cause undefined behaviour.
   """
   @callback merge_frames(
-              frames :: [{id_t, binary()}],
-              internal_state :: any()
-            ) :: {{:ok, merged_frames :: binary()}, state :: any()}
+              internal_state :: internal_state_t,
+              frames :: [{id_t, binary()}]
+            ) :: {{:ok, merged_frames :: binary()}, internal_state_t} | {:error, error_t()}
 
   @doc """
   Registers a new input video with the given numerical `id`.
   Provided `id` should be unique within all previous ones, otherwise function may cause undefined behaviour.
   """
   @callback add_video(
+              internal_state :: internal_state_t,
               id :: id_t(),
               input_caps :: RawVideo.t(),
-              position :: {x :: non_neg_integer(), y :: non_neg_integer()},
-              internal_state :: any()
-            ) :: {:ok, state :: any()}
+              position :: {x :: non_neg_integer(), y :: non_neg_integer()}
+            ) :: {:ok, internal_state_t} | {:error, error_t()}
 
   @doc """
   Video of the given `id` should be registered, removal of nonexistent video may cause undefined behaviour.
   """
   @callback remove_video(
-              id :: id_t(),
-              internal_state :: any()
-            ) :: {:ok, state :: any()}
+              internal_state :: internal_state_t,
+              id :: id_t()
+            ) :: {:ok, internal_state_t} | {:error, error_t()}
 
   @doc """
   Video of the given `id` should be registered, using `id` of nonexistent video may cause undefined behaviour.
   """
   @callback set_position(
+              internal_state :: internal_state_t,
               id :: id_t(),
-              position :: {x :: non_neg_integer(), y :: non_neg_integer()},
-              internal_state :: any()
-            ) :: {:ok, state :: any()}
+              position :: {x :: non_neg_integer(), y :: non_neg_integer()}
+            ) :: {:ok, internal_state_t} | {:error, error_t()}
 end

--- a/lib/membrane/video_compositor/implementations/opengl/rust.ex
+++ b/lib/membrane/video_compositor/implementations/opengl/rust.ex
@@ -13,24 +13,24 @@ defmodule Membrane.VideoCompositor.OpenGL.Rust do
   end
 
   @impl true
-  def add_video(id, input_caps, position, internal_state) do
+  def add_video(internal_state, id, input_caps, position) do
     {:ok, input_caps} = Rust.RawVideo.from_membrane_raw_video(input_caps)
     {:ok, position} = Rust.Position.from_tuple(position)
     {Rust.add_video(internal_state, id, input_caps, position), internal_state}
   end
 
   @impl true
-  def remove_video(id, internal_state) do
+  def remove_video(internal_state, id) do
     {Rust.remove_video(internal_state, id), internal_state}
   end
 
   @impl true
-  def merge_frames(frames, internal_state) do
+  def merge_frames(internal_state, frames) do
     {Rust.join_frames(internal_state, frames), internal_state}
   end
 
   @impl true
-  def set_position(id, position, internal_state) do
+  def set_position(internal_state, id, position) do
     {:ok, position} = Rust.Position.from_tuple(position)
     {Rust.set_position(internal_state, id, position), internal_state}
   end

--- a/test/support/mock/frame_composer.ex
+++ b/test/support/mock/frame_composer.ex
@@ -15,7 +15,7 @@ defmodule Membrane.VideoCompositor.Test.Support.Mock.FrameComposer do
   end
 
   @impl true
-  def merge_frames(frames, %{merged_ids: merged_ids} = internal_state) do
+  def merge_frames(%{merged_ids: merged_ids} = internal_state, frames) do
     {ids, frames} = Enum.unzip(frames)
     internal_state = %{internal_state | merged_ids: [ids | merged_ids]}
 
@@ -28,26 +28,26 @@ defmodule Membrane.VideoCompositor.Test.Support.Mock.FrameComposer do
 
   @impl true
   def add_video(
+        %{inputs: inputs} = internal_state,
         id,
         input_caps,
-        _position,
-        %{inputs: inputs} = internal_state
+        _position
       ) do
     internal_state = %{internal_state | inputs: Map.put(inputs, id, input_caps)}
     {:ok, internal_state}
   end
 
   @impl true
-  def remove_video(id, %{inputs: inputs} = internal_state) do
+  def remove_video(%{inputs: inputs} = internal_state, id) do
     internal_state = %{internal_state | inputs: Map.delete(inputs, id)}
     {:ok, internal_state}
   end
 
   @impl true
   def set_position(
+        internal_state,
         _id,
-        _position,
-        internal_state
+        _position
       ) do
     {:ok, internal_state}
   end


### PR DESCRIPTION
Due to an oversight, `FrameComposer` behavior had `internal_state`
as the last argument in all callbacks. We decided this
parameter should always be first.
Additionally, provide better typing into the behavior declarations.