### PR TITLE
Replace explicit error handling with exceptions

### DIFF
--- a/lib/membrane/video_compositor/scene/component.ex
+++ b/lib/membrane/video_compositor/scene/component.ex
@@ -9,7 +9,6 @@ defmodule Membrane.VideoCompositor.Scene.Component do
   @type target_state_t() :: any()
   @type options_t() :: any()
   @type state_t() :: any()
-  @type error_t() :: any()
   @type context_t() :: any()
 
   @doc """
@@ -22,16 +21,15 @@ defmodule Membrane.VideoCompositor.Scene.Component do
   If module `use_caching?/0`, result will be stored and shared between all initializations.
   Otherwise, it will be called during all registrations.
   """
-  @callback handle_init(options_t(), context :: any()) ::
-              {:ok, state_t()} | {:error, error_t()}
+  @callback handle_init(options_t(), context :: any()) :: state_t()
 
   @doc """
   Component can ensure target state contains some common properties (position, mesh, etc.)
   or inject own, unique state to the target (percent of completeness, etc.)
   """
   @callback inject_into_target_state(target_state_t(), state_t(), id :: atom()) ::
-              {:ok, target_state_t()} | {:error, error_t()}
+              target_state_t()
 
   @callback handle_update(target_state_t(), state_t(), id :: atom(), context :: any()) ::
-              {:ok, {:done | :ongoing, target_state_t()}} | {:error, error_t()}
+              {:done | :ongoing, target_state_t()}
 end

--- a/lib/membrane/video_compositor/scene/element.ex
+++ b/lib/membrane/video_compositor/scene/element.ex
@@ -2,7 +2,6 @@ defmodule Membrane.VideoCompositor.Scene.Element do
   @moduledoc """
   Set of universal elements types.
   """
-  @type error_t :: any()
   @type component_t :: module()
   @type components_t :: keyword(component_t())
 end

--- a/lib/membrane/video_compositor/scene/element_description.ex
+++ b/lib/membrane/video_compositor/scene/element_description.ex
@@ -12,8 +12,6 @@ defmodule Membrane.VideoCompositor.Scene.ElementDescription do
 
   @type components_t :: keyword({component_t(), options_t})
 
-  @type error_t :: any()
-
   @type t :: %__MODULE__{
           state: any(),
           components: components_t()

--- a/lib/membrane/video_compositor/scene/video.ex
+++ b/lib/membrane/video_compositor/scene/video.ex
@@ -24,15 +24,9 @@ defmodule Membrane.VideoCompositor.Scene.Video do
     }
   end
 
-  @spec update(t, Manager.t(), context :: any) :: {:ok, t} | {:error, error_t}
+  @spec update(t, Manager.t(), context :: any) :: t
   def update(video, manager, context) do
-    case Manager.update(video.state, video.components, manager, context) do
-      {:ok, {state, components}} ->
-        video = %Video{video | state: state, components: components}
-        {:ok, video}
-
-      {:error, error} ->
-        {:error, error}
-    end
+    {state, components} = Manager.update(video.state, video.components, manager, context)
+    %Video{video | state: state, components: components}
   end
 end

--- a/test/scene/component_test.exs
+++ b/test/scene/component_test.exs
@@ -13,22 +13,22 @@ defmodule Membrane.VideoCompositor.Test.Scene.Component do
 
     @impl true
     def handle_init(_options \\ nil, _context \\ nil) do
-      {:ok, %{count: 0}}
+      %{count: 0}
     end
 
     @impl true
     def inject_into_target_state(target, state, id) do
-      {:ok, Map.put(target, id, 0) |> Map.put(:state, state)}
+      Map.put(target, id, 0) |> Map.put(:state, state)
     end
 
     @impl true
     def handle_update(_target_state, _state, _id, :error) do
-      {:error, "Error msg"}
+      raise "Error msg"
     end
 
     @impl true
     def handle_update(target_state, _state, _id, :done) do
-      {:ok, {:done, target_state}}
+      {:done, target_state}
     end
 
     @impl true
@@ -39,7 +39,7 @@ defmodule Membrane.VideoCompositor.Test.Scene.Component do
         Map.put(target_state, id, time)
         |> Map.put(:state, state)
 
-      {:ok, {:ongoing, target_state}}
+      {:ongoing, target_state}
     end
   end
 
@@ -48,29 +48,27 @@ defmodule Membrane.VideoCompositor.Test.Scene.Component do
 
     assert not Mock.Add.use_caching?()
 
-    assert {:ok, %{count: 0} = state} = Mock.Add.handle_init()
+    assert %{count: 0} = state = Mock.Add.handle_init()
 
-    assert {:ok, %{target: 0} = target_state} =
-             Mock.Add.inject_into_target_state(target_state, state, :target)
+    assert %{target: 0} =
+             target_state = Mock.Add.inject_into_target_state(target_state, state, :target)
 
-    assert {:ok, {:ongoing, target_state}} =
-             Mock.Add.handle_update(target_state, state, :target, 6)
+    assert {:ongoing, target_state} = Mock.Add.handle_update(target_state, state, :target, 6)
 
     assert %{target: 6, state: %{count: 1}} = target_state
 
-    assert {:ok, {:ongoing, target_state}} =
-             Mock.Add.handle_update(target_state, state, :target, 3)
+    assert {:ongoing, target_state} = Mock.Add.handle_update(target_state, state, :target, 3)
 
     assert %{target: 3, state: %{count: 2}} = target_state
 
-    assert {:ok, {:ongoing, target_state}} =
-             Mock.Add.handle_update(target_state, state, :target, 1)
+    assert {:ongoing, target_state} = Mock.Add.handle_update(target_state, state, :target, 1)
 
     assert %{target: 1, state: %{count: 3}} = target_state
 
-    assert {:ok, {:done, target_state}} =
-             Mock.Add.handle_update(target_state, state, :target, :done)
+    assert {:done, target_state} = Mock.Add.handle_update(target_state, state, :target, :done)
 
-    assert {:error, "Error msg"} = Mock.Add.handle_update(target_state, state, :target, :error)
+    assert_raise RuntimeError, "Error msg", fn ->
+      Mock.Add.handle_update(target_state, state, :target, :error)
+    end
   end
 end

--- a/test/scene/components_manager_test.exs
+++ b/test/scene/components_manager_test.exs
@@ -9,31 +9,31 @@ defmodule Membrane.VideoCompositor.Test.Scene.ComponentsManager do
 
     manager = %Manager{}
 
-    assert {:ok, {manager, target_state}} =
+    assert {manager, target_state} =
              Manager.register(manager, target_state, Mocks.Stateless.Add, :add)
 
     assert %{count: 0} = Map.get(target_state, :add)
 
     set_amount = 20
 
-    assert {:ok, {manager, target_state}} =
+    assert {manager, target_state} =
              Manager.register(manager, target_state, Mocks.Stateful.Set, :set, set_amount)
 
     assert 0 = Map.get(target_state, :set)
 
     components = [set: Mocks.Stateful.Set, add: Mocks.Stateless.Add]
 
-    assert {:ok, {target_state, components}} =
-             Manager.update(target_state, components, manager, nil)
+    assert {target_state, components} = Manager.update(target_state, components, manager, nil)
 
     assert components == [set: Mocks.Stateful.Set, add: Mocks.Stateless.Add]
 
     assert %{set: 20, add: %{count: 1}} = target_state
 
-    assert {:error, "Error msg set"} = Manager.update(target_state, components, manager, :error)
+    assert_raise RuntimeError, "Error msg set", fn ->
+      Manager.update(target_state, components, manager, :error)
+    end
 
-    assert {:ok, {_target_state, components}} =
-             Manager.update(target_state, components, manager, :done)
+    assert {_target_state, components} = Manager.update(target_state, components, manager, :done)
 
     assert Enum.empty?(components)
   end

--- a/test/scene/scene_test.exs
+++ b/test/scene/scene_test.exs
@@ -37,7 +37,7 @@ defmodule Membrane.VideoCompositor.Test.Scene.Initialization do
 
   describe "Scene" do
     test "static initialization", %{scene_description: scene_description, manager: manager} do
-      assert {:ok, {scene, manager}} = Scene.init(scene_description, manager)
+      assert {scene, manager} = Scene.init(scene_description, manager)
 
       expected_scene_state = %Scene{
         components: [
@@ -82,9 +82,9 @@ defmodule Membrane.VideoCompositor.Test.Scene.Initialization do
     end
 
     test "update ok", %{scene_description: scene_description, manager: manager} do
-      assert {:ok, {scene, manager}} = Scene.init(scene_description, manager)
+      assert {scene, manager} = Scene.init(scene_description, manager)
 
-      assert {:ok, scene} = Scene.update(scene, manager, 10)
+      assert scene = Scene.update(scene, manager, 10)
 
       expected_updated_scene = %Scene{
         components: [
@@ -121,15 +121,15 @@ defmodule Membrane.VideoCompositor.Test.Scene.Initialization do
     end
 
     test "update error", %{scene_description: scene_description, manager: manager} do
-      assert {:ok, {scene, manager}} = Scene.init(scene_description, manager)
+      assert {scene, manager} = Scene.init(scene_description, manager)
 
-      assert {:error, "Error msg set"} = Scene.update(scene, manager, :error)
+      assert_raise RuntimeError, "Error msg set", fn -> Scene.update(scene, manager, :error) end
     end
 
     test "update done", %{scene_description: scene_description, manager: manager} do
-      assert {:ok, {scene, manager}} = Scene.init(scene_description, manager)
+      assert {scene, manager} = Scene.init(scene_description, manager)
 
-      assert {:ok, scene} = Scene.update(scene, manager, :done)
+      assert scene = Scene.update(scene, manager, :done)
 
       expected_done_scene = %Scene{
         components: [],

--- a/test/support/scene/mocks/stateful/set.ex
+++ b/test/support/scene/mocks/stateful/set.ex
@@ -9,28 +9,28 @@ defmodule Membrane.VideoCompositor.Test.Support.Scene.Mocks.Stateful.Set do
 
   @impl true
   def handle_init(amount, _context \\ nil) do
-    {:ok, amount}
+    amount
   end
 
   @impl true
   def inject_into_target_state(target, _state, id) do
-    {:ok, Map.put(target, id, 0)}
+    Map.put(target, id, 0)
   end
 
   @impl true
   def handle_update(_target_state, _state, _id, :error) do
-    {:error, "Error msg set"}
+    raise "Error msg set"
   end
 
   @impl true
   def handle_update(target_state, _state, _id, :done) do
-    {:ok, {:done, target_state}}
+    {:done, target_state}
   end
 
   @impl true
   def handle_update(target_state, amount, id, _time) do
     target_state = Map.put(target_state, id, amount)
 
-    {:ok, {:ongoing, target_state}}
+    {:ongoing, target_state}
   end
 end

--- a/test/support/scene/mocks/stateless/add.ex
+++ b/test/support/scene/mocks/stateless/add.ex
@@ -9,22 +9,22 @@ defmodule Membrane.VideoCompositor.Test.Support.Scene.Mocks.Stateless.Add do
 
   @impl true
   def handle_init(_options \\ nil, _context \\ nil) do
-    {:ok, nil}
+    nil
   end
 
   @impl true
   def inject_into_target_state(target, nil = _state, id) do
-    {:ok, Map.put(target, id, %{count: 0})}
+    Map.put(target, id, %{count: 0})
   end
 
   @impl true
   def handle_update(_target_state, nil = _state, _id, :error) do
-    {:error, "Error msg add"}
+    raise "Error msg add"
   end
 
   @impl true
   def handle_update(target_state, nil = _state, _id, :done) do
-    {:ok, {:done, target_state}}
+    {:done, target_state}
   end
 
   @impl true
@@ -36,6 +36,6 @@ defmodule Membrane.VideoCompositor.Test.Support.Scene.Mocks.Stateless.Add do
         fn state -> Map.update!(state, :count, &(&1 + 1)) end
       )
 
-    {:ok, {:ongoing, target_state}}
+    {:ongoing, target_state}
   end
 end


### PR DESCRIPTION
Most potential scene system failures will be related to NIF internal errors beyond recovery. In this case, the whole system should fail as well.