### PR TITLE
Remove information about compiling Google ANGLE from the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ end
 
 Since parts of this package are implemented in Rust, you need to have a Rust installation to compile this package. You can get one [here](https://rustup.rs/)
 
-To compile on macOS, first get and compile [Google ANGLE](https://github.com/google/angle/blob/main/doc/DevSetup.md) with `is_component_build = false` and place the resulting `libEGL.dylib` and `libGLESv2.dylib` in the root of this package.
-
 ## Usage
 
 TODO


### PR DESCRIPTION
This is unnecessary since we don't use OpenGL anymore.