### PR TITLE
Make the compostor handle adding pads dynamically in offline mode.

### DIFF
--- a/native/membrane_videocompositor/src/compositor.rs
+++ b/native/membrane_videocompositor/src/compositor.rs
@@ -294,6 +294,7 @@ impl State {
 
         let mut pts = 0;
         let mut ended_video_ids = Vec::new();
+        let mut rendered_video_ids = Vec::new();
 
         {
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -318,10 +319,12 @@ impl State {
 
             render_pass.set_pipeline(&self.pipeline);
             render_pass.set_bind_group(1, &self.sampler.bind_group, &[]);
-
             for (&id, video) in self.input_videos.iter_mut() {
-                match video.draw(&self.queue, &mut render_pass, &self.output_caps) {
-                    DrawResult::Rendered(new_pts) => pts = pts.max(new_pts),
+                match video.draw(&self.queue, &mut render_pass, &self.output_caps, interval) {
+                    DrawResult::Rendered(new_pts) => {
+                        pts = pts.max(new_pts);
+                        rendered_video_ids.push(id);
+                    }
                     DrawResult::NotRendered => {}
                     DrawResult::EndOfStream => ended_video_ids.push(id),
                 }
@@ -331,7 +334,10 @@ impl State {
         ended_video_ids.iter().for_each(|id| {
             self.input_videos.remove(id);
         });
-        self.input_videos.values_mut().for_each(|v| v.pop_frame());
+
+        rendered_video_ids
+            .iter()
+            .for_each(|id| self.input_videos.get_mut(id).unwrap().pop_frame());
 
         self.queue.submit(Some(encoder.finish()));
 
@@ -541,5 +547,58 @@ mod tests {
 
         compositor.upload_texture(2, FRAME, 500_000_000).unwrap();
         assert!(compositor.all_frames_ready());
+    }
+
+    #[test]
+    fn just_added_video_with_too_new_frames() -> Result<(), CompositorError> {
+        let mut compositor = setup_videos(2);
+
+        // first, we remove vid 1, since for this test we need a video that was used in
+        // composition already and one that wasn't. Next couple lines set this state up.
+        compositor.remove_video(1)?;
+
+        compositor.upload_texture(0, FRAME, 0)?;
+        assert!(compositor.all_frames_ready());
+        pollster::block_on(compositor.draw_into(&mut [0; 12]));
+
+        compositor.add_video(
+            1,
+            VideoProperties {
+                resolution: Vec2d { x: 2, y: 2 },
+                layout: VideoLayout {
+                    position: Vec2d { x: 2, y: 0 },
+                    size: Vec2d { x: 2, y: 2 },
+                    z: 0.0,
+                },
+            },
+        )?;
+
+        compositor.upload_texture(0, FRAME, 500_000_000)?;
+        // vid 1 was just added. Before the compositor sees any frames from vid 1,
+        // it has to assume that those may be needed for composing current frames.
+        assert!(!compositor.all_frames_ready());
+
+        compositor.upload_texture(1, FRAME, 1_250_000_000)?;
+        // now that the compositor has seen a vid 1 frame and decided it is 'too new'
+        // to be used now, it shouldn't block on waiting for vid 1 frames.
+        assert!(compositor.all_frames_ready());
+
+        pollster::block_on(compositor.draw_into(&mut [0; 12]));
+        // now a frame for vid 0 is missing.
+        assert!(!compositor.all_frames_ready());
+
+        compositor.upload_texture(0, FRAME, 1_250_000_000)?;
+        // now vids 0 and 1 have same timestamps
+        assert!(compositor.all_frames_ready());
+
+        pollster::block_on(compositor.draw_into(&mut [0; 12]));
+        // now there are no frames
+        assert!(!compositor.all_frames_ready());
+
+        compositor.upload_texture(0, FRAME, 2_000_000_000)?;
+        // now the compositor should block on waiting for vid 1 frames.
+        assert!(!compositor.all_frames_ready());
+
+        Ok(())
     }
 }

--- a/native/membrane_videocompositor/src/compositor.rs
+++ b/native/membrane_videocompositor/src/compositor.rs
@@ -565,7 +565,7 @@ mod tests {
             1,
             VideoProperties {
                 resolution: Vec2d { x: 2, y: 2 },
-                layout: VideoLayout {
+                placement: VideoPlacement {
                     position: Vec2d { x: 2, y: 0 },
                     size: Vec2d { x: 2, y: 2 },
                     z: 0.0,

--- a/native/membrane_videocompositor/src/compositor/textures.rs
+++ b/native/membrane_videocompositor/src/compositor/textures.rs
@@ -8,6 +8,7 @@ pub enum YUVPlane {
     V,
 }
 
+#[derive(Debug)]
 pub struct Texture {
     desc: wgpu::TextureDescriptor<'static>,
     texture: wgpu::Texture,
@@ -100,6 +101,7 @@ impl Texture {
     }
 }
 
+#[derive(Debug)]
 pub struct YUVTextures {
     planes: [Texture; 3],
     pub bind_group: Option<wgpu::BindGroup>,
@@ -329,6 +331,7 @@ impl OutputTextures {
     }
 }
 
+#[derive(Debug)]
 pub struct RGBATexture {
     pub texture: Texture,
 }

--- a/native/membrane_videocompositor/src/compositor/videos.rs
+++ b/native/membrane_videocompositor/src/compositor/videos.rs
@@ -24,6 +24,7 @@ pub struct VideoLayout {
     pub z: f32,
 }
 
+#[derive(Debug)]
 pub enum Message {
     Frame { pts: u64, frame: RGBATexture },
     EndOfStream,
@@ -42,6 +43,7 @@ const INDICES: [u16; 6] = [
     1, 2, 3
 ];
 
+#[derive(Debug)]
 pub struct InputVideo {
     frames: VecDeque<Message>,
     yuv_textures: YUVTextures,
@@ -50,6 +52,11 @@ pub struct InputVideo {
     properties: VideoProperties,
     previous_frame: Option<Message>,
     single_texture_bind_group_layout: Arc<wgpu::BindGroupLayout>,
+    /// When a video is created this is set to `true`. When `draw` is later called on it,
+    /// until the first frame form this video's queue is composed, it won't block the compositor
+    /// while it's frames are considered 'too new'. When the first frame from this video is composed,
+    /// this gets set to `false` and the video operates normally.
+    was_just_added: bool,
 }
 
 impl InputVideo {
@@ -91,6 +98,7 @@ impl InputVideo {
             properties,
             previous_frame: None,
             single_texture_bind_group_layout,
+            was_just_added: true,
         }
     }
 
@@ -214,6 +222,7 @@ impl InputVideo {
         queue: &wgpu::Queue,
         render_pass: &mut wgpu::RenderPass<'a>,
         output_caps: &crate::RawVideo,
+        frame_interval: Option<(u64, u64)>,
     ) -> DrawResult {
         queue.write_buffer(
             &self.vertices,
@@ -222,7 +231,16 @@ impl InputVideo {
         );
 
         let (frame, pts) = match self.frames.front() {
-            Some(Message::Frame { frame, pts }) => (frame, *pts),
+            Some(Message::Frame { frame, pts }) => {
+                // this is the case when the video was just added and its frames are 'too new'
+                if let Some((_, end)) = frame_interval {
+                    if *pts > end && self.was_just_added {
+                        return DrawResult::NotRendered;
+                    }
+                }
+
+                (frame, *pts)
+            }
 
             Some(Message::EndOfStream) => return DrawResult::EndOfStream,
 
@@ -243,6 +261,8 @@ impl InputVideo {
         let indices_len = (self.indices.size() / std::mem::size_of::<u16>() as u64) as u32;
 
         render_pass.draw_indexed(0..indices_len, 0, 0..1);
+
+        self.was_just_added = false;
 
         DrawResult::Rendered(pts)
     }
@@ -280,10 +300,27 @@ impl InputVideo {
             return true;
         }
 
-        self.front_pts().is_some() // if the stream hasn't ended then we have to have a frame in the queue, then either:
-            && (interval.is_none() // this is the first frame, which means a frame with any pts is good
-                || (interval.unwrap().0 <= self.front_pts().unwrap()
-                    && self.front_pts().unwrap() <= interval.unwrap().1)) // or we have to fit between the start and end pts
+        // if the stream hasn't ended then we have to have a frame in the queue, then either:
+        if self.front_pts().is_some() {
+            // this is the first frame, which means a frame with any pts is good
+            if interval.is_none() {
+                return true;
+            }
+
+            // or we have to fit between the start and end pts
+            if interval.unwrap().0 <= self.front_pts().unwrap()
+                && self.front_pts().unwrap() <= interval.unwrap().1
+            {
+                return true;
+            }
+
+            // or this video was just added, and frames in it's queue are 'too new'
+            if self.was_just_added {
+                return true;
+            }
+        }
+
+        false
     }
 }
 


### PR DESCRIPTION
Previously, when a pad was added in offline mode, the compositor could enter a sort of deadlock when it wouldn't spit out any frames.

This was fixed by marking new videos as 'just added'. This flag gets unset when a video has had it's frame used for composition at least once. Until this happens, the video gets ignored if it's frames are 'too new' for composing.