### PR TITLE
Fix update properties

### DIFF
--- a/lib/membrane/compositor_element.ex
+++ b/lib/membrane/compositor_element.ex
@@ -247,7 +247,7 @@ defmodule Membrane.VideoCompositor.CompositorElement do
             :ok ->
               initial_video_placements
             {:error, :bad_video_index} ->
-              # in case we update placement before reciving caps from pad
+              # in case we update placement before receiving caps from pad
               Map.put(initial_video_placements, id, placement)
           end
           initial_video_placements

--- a/lib/membrane/compositor_element.ex
+++ b/lib/membrane/compositor_element.ex
@@ -239,7 +239,7 @@ defmodule Membrane.VideoCompositor.CompositorElement do
     } = state
 
     initial_video_placements =
-      Enum.each(
+      Enum.map(
         placements,
         fn {pad, placement} ->
           id = Map.fetch!(pads_to_ids, pad)

--- a/lib/membrane/compositor_element.ex
+++ b/lib/membrane/compositor_element.ex
@@ -239,25 +239,36 @@ defmodule Membrane.VideoCompositor.CompositorElement do
     } = state
 
     initial_video_placements =
-      Enum.map(
-        placements,
-        fn {pad, placement} ->
-          id = Map.fetch!(pads_to_ids, pad)
-
-          initial_video_placements =
-            case Wgpu.update_placement(wgpu_state, id, placement) do
-              :ok ->
-                initial_video_placements
-
-              {:error, :bad_video_index} ->
-                # in case we update placement before receiving caps from pad
-                Map.put(initial_video_placements, id, placement)
-            end
-
-          initial_video_placements
-        end
-      )
+      update_placements(placements, pads_to_ids, wgpu_state, initial_video_placements)
 
     {:ok, %{state | initial_video_placements: initial_video_placements}}
+  end
+
+  defp update_placements(
+         [],
+         _pads_to_ids,
+         _wgpu_state,
+         initial_video_placements
+       ) do
+    initial_video_placements
+  end
+
+  defp update_placements(
+         [{pad, placement} | other_placements],
+         pads_to_ids,
+         wgpu_state,
+         initial_video_placements
+       ) do
+    id = Map.get(pads_to_ids, pad)
+
+    initial_video_placements =
+      case Wgpu.update_placement(wgpu_state, id, placement) do
+        :ok -> initial_video_placements
+        # in case of update_placements is called before handle_caps and add_video in rust
+        # wasn't called yet (the video wasn't registered in rust yet)
+        {:error, :bad_video_index} -> Map.put(initial_video_placements, id, placement)
+      end
+
+    update_placements(other_placements, pads_to_ids, wgpu_state, initial_video_placements)
   end
 end

--- a/lib/membrane/compositor_element.ex
+++ b/lib/membrane/compositor_element.ex
@@ -243,13 +243,17 @@ defmodule Membrane.VideoCompositor.CompositorElement do
         placements,
         fn {pad, placement} ->
           id = Map.fetch!(pads_to_ids, pad)
-          initial_video_placements = case Wgpu.update_placement(wgpu_state, id, placement) do
-            :ok ->
-              initial_video_placements
-            {:error, :bad_video_index} ->
-              # in case we update placement before receiving caps from pad
-              Map.put(initial_video_placements, id, placement)
-          end
+
+          initial_video_placements =
+            case Wgpu.update_placement(wgpu_state, id, placement) do
+              :ok ->
+                initial_video_placements
+
+              {:error, :bad_video_index} ->
+                # in case we update placement before receiving caps from pad
+                Map.put(initial_video_placements, id, placement)
+            end
+
           initial_video_placements
         end
       )

--- a/lib/membrane/video_compositor/wgpu/wgpu.ex
+++ b/lib/membrane/video_compositor/wgpu/wgpu.ex
@@ -111,7 +111,7 @@ defmodule Membrane.VideoCompositor.Wgpu do
   def update_placement(state, id, placement) do
     case Native.update_placement(state, id, placement) do
       :ok -> :ok
-      {:error, :bad_video_index} -> {:error, :bad_video_index}
+      {:error, {:bad_video_index, _index}} -> {:error, :bad_video_index}
       {:error, reason} -> raise "Error while updating video placement, reason: #{inspect(reason)}"
     end
   end

--- a/lib/membrane/video_compositor/wgpu/wgpu.ex
+++ b/lib/membrane/video_compositor/wgpu/wgpu.ex
@@ -107,10 +107,11 @@ defmodule Membrane.VideoCompositor.Wgpu do
           state :: wgpu_state_t(),
           id :: id_t(),
           placement :: RustStructs.VideoPlacement.t()
-        ) :: :ok
+        ) :: :ok | {:error, :bad_video_index}
   def update_placement(state, id, placement) do
     case Native.update_placement(state, id, placement) do
       :ok -> :ok
+      {:error, :bad_video_index} -> {:error, :bad_video_index}
       {:error, reason} -> raise "Error while updating video placement, reason: #{inspect(reason)}"
     end
   end


### PR DESCRIPTION
Fix error ocurring, when we call `update_placements` before `handle_caps` (when rust hasn't registered video yet)