### PR TITLE
Allow SMELTER_WEB_RENDERER_ENABLE to be set via environment variable

### DIFF
--- a/lib/membrane/smelter/server_runner.ex
+++ b/lib/membrane/smelter/server_runner.ex
@@ -162,7 +162,7 @@ defmodule Membrane.Smelter.ServerRunner do
     env =
       Map.merge(env, %{
         "SMELTER_API_PORT" => to_string(lc_port),
-        "SMELTER_WEB_RENDERER_ENABLE" => "false"
+        "SMELTER_WEB_RENDERER_ENABLE" => System.get_env("SMELTER_WEB_RENDERER_ENABLE", "false")
       })
 
     spec =


### PR DESCRIPTION
The web renderer enable flag was hardcoded to "false". Now reads from System.get_env with "false" as default, allowing users to enable the web renderer by setting SMELTER_WEB_RENDERER_ENABLE=true.